### PR TITLE
Refactor analysis handling and fix minor typos in report generation

### DIFF
--- a/analyze_repo.py
+++ b/analyze_repo.py
@@ -114,13 +114,18 @@ def format_structure(structure):
             lines.append(f"{indent}    {f}")
             if index < len(analyses) and analyses[index]:
                 analysis = analyses[index]
-                if analysis == "NOT_ANALYZED":
-                    lines.append(f"{indent}    ※解析対象外\n")
-                else:
+                if isinstance(analysis, dict):
                     file_type = analysis.get('file_type', '---')
                     description = analysis.get('description', '---')
                     lines.append(f"{indent}    {file_type}")
                     lines.append(f"{indent}    {description}\n")
+                elif analysis == "NOT_ANALYZED":
+                    lines.append(f"{indent}    ※解析対象外\n")
+                elif analysis == "FILE_READ_ERROR":
+                    lines.append(f"{indent}    ※ファイル読み取りエラー\n")
+                else:
+                    raise ValueError(f"Unexpected analysis result: {analysis}")
+
     return '\n'.join(lines)
 
 def write_stats_to_file(stats, filename):

--- a/chat.py
+++ b/chat.py
@@ -35,10 +35,7 @@ def format_structure_common(structure, with_description=False):
             if with_description:
                 if 0 <= index < len(analyses):
                     analysis = analyses[index]
-                    if analysis == "NOT_ANALYZED":
-                        lines.append(f"■ {f}")
-                        lines.append(f" - ※解析対象外\n")
-                    else:
+                    if isinstance(analysis, dict):
                         file_type = analysis.get('file_type', '---')
                         description = analysis.get('description', '---')
                         references = analysis.get('references', [])
@@ -54,6 +51,14 @@ def format_structure_common(structure, with_description=False):
                         lines.append(f"\n# ファイルパス")
                         lines.append(f"  - {root}/{f}")
                         lines.append("\n")
+                    elif analysis == "NOT_ANALYZED":
+                        lines.append(f"■ {f}")
+                        lines.append(f" - ※解析対象外\n")
+                    elif analysis == "FILE_READ_ERROR":
+                        lines.append(f"■ {f}")
+                        lines.append(f" - ※ファイル読み取りエラー\n")
+                    else:
+                        raise ValueError(f"Unexpected analysis result: {analysis}")
             else:
                 lines.append(f"{indent}    {f}")
     return '\n'.join(lines)

--- a/report.py
+++ b/report.py
@@ -19,7 +19,7 @@ html_content = f"""
         th, td {{ border: 1px solid #ccc; padding: 8px; text-align: left; }}
         th {{ background-color: #f4f4f4; }}
         .not-analyzed {{ color: #999; }}
-        .direcotry {{ background-color: #a4a4ff; }}
+        .directory {{ background-color: #a4a4ff; }}
         .file-name {{ width: 15%; font-size: 1.2em; }}
         .file-type {{ width: 15%; }}
         .description {{ width: 50%; font-size:0.9em;}}
@@ -38,7 +38,7 @@ html_content = f"""
 for folder in data['structure']:
     if folder[2]:  # ファイルが存在するフォルダのみ表示
         html_content += f"""
-        <h2 class="direcotry" >ディレクトリ: {folder[0]}</h2>
+        <h2 class="directory" >ディレクトリ: {folder[0]}</h2>
         <table>
             <thead>
                 <tr>
@@ -52,7 +52,7 @@ for folder in data['structure']:
             <tbody>
         """
         for file, analysis in zip(folder[2], folder[3]):
-            if analysis != "NOT_ANALYZED":
+            if isinstance(analysis, dict):
                 description_html = markdown2.markdown(analysis['description'])
                 html_content += f"""
                 <tr>


### PR DESCRIPTION
分析結果の JSON ファイルの読み込み処理でファイル読み込みエラーのパターンに対応していない部分を修正しました。
レポート時は OpenAI で解析できたかどうかが重要なので、分析できたかどうかだけを判定するようにしました。
細かい Typo がありましたので一緒に修正しましたが、分けた方がよければコメントしてください。